### PR TITLE
Default to python3 on Debian 9

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1451,7 +1451,7 @@ INTERPRETER_PYTHON_DISTRO_MAP:
       '6': /usr/bin/python
       '8': /usr/libexec/platform-python
     debian:
-      '9': /usr/bin/python3
+      '10': /usr/bin/python3
     fedora:
       '23': /usr/bin/python3
     redhat: *rhelish

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1450,6 +1450,8 @@ INTERPRETER_PYTHON_DISTRO_MAP:
     centos: &rhelish
       '6': /usr/bin/python
       '8': /usr/libexec/platform-python
+    debian:
+      '9': /usr/bin/python3
     fedora:
       '23': /usr/bin/python3
     redhat: *rhelish

--- a/test/integration/targets/interpreter_discovery_python/tasks/main.yml
+++ b/test/integration/targets/interpreter_discovery_python/tasks/main.yml
@@ -115,7 +115,7 @@
     assert:
       that:
       - auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python3'
-    when: distro == 'debian' and distro_version is version('9', '>=')
+    when: distro == 'debian' and distro_version is version('10', '>=')
 
   - name: fedora assertions
     assert:

--- a/test/integration/targets/interpreter_discovery_python/tasks/main.yml
+++ b/test/integration/targets/interpreter_discovery_python/tasks/main.yml
@@ -111,6 +111,12 @@
       - ansible_facts['ansible_bogus_interpreter'] | default('nope') == 'nope'
       - ansible_facts['discovered_interpreter_bogus'] | default('nope') == 'nope'
 
+  - name: debian assertions
+    assert:
+      that:
+      - auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python3'
+    when: distro == 'debian' and distro_version is version('9', '>=')
+
   - name: fedora assertions
     assert:
       that:


### PR DESCRIPTION
##### SUMMARY
Like Ubuntu 16, Debian 9 comes with both python2 and python3. Again like Ubuntu 16, I propose to default to python3 when using `ansible_python_interpreter = auto`.

People that want to stick to the python 2, can set `ansible_python_interpreter = auto_legacy` to default to python 2 (which is currently still the default setting).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
BaseAction
